### PR TITLE
Update to support k8s >= v1.16

### DIFF
--- a/k8s_resources/planning-poker-deployment.yaml
+++ b/k8s_resources/planning-poker-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
Based on https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/, it looks like all we need to do is switch from `extensions/v1beta1` (no longer served as of v1.16) to `apps/v1` (available since 1.9, and supports all the parameters used by this deployment).

* [ ] Test with k8s >= v1.16